### PR TITLE
Add Default Sass Charset

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ kramdown:
 
 # Sass settings
 sass:
+  add_charset: true
   sass_dir: assets/sass
   style: :compressed
 


### PR DESCRIPTION
Per this change: https://github.com/jekyll/jekyll-sass-converter/releases/tag/v1.4.0
