### PR TITLE
Remove redundant options

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,9 +16,6 @@ url: "http://yourdomain.com" # the base hostname & protocol for your site
 
 # Markdown settings
 markdown: kramdown
-kramdown:
-  input: GFM
-  syntax_highlighter: rouge
 
 # Sass settings
 sass:
@@ -28,15 +25,12 @@ sass:
 
 # Build settings
 exclude:
-  - Gemfile
-  - Gemfile.lock
   - package.json
   - README.md
   - CNAME
-  - node_modules
   - assets/sass
 
 # Plugin settings
-gems:
+plugins:
   - jekyll-feed
   - jekyll-sitemap


### PR DESCRIPTION
Some cleanup in the `_config.yml`: 

- Rouge is the default highlighter since three years,
- Kramdown default options include `input: GFM`
- `Gemfile`, `Gemfile.lock` and `node_modules` are excluded by default since Jekyll v3.5.0
- `gems` config key has been renamed to `plugins` since v3.6.0

Default options are defined in
https://raw.githubusercontent.com/jekyll/jekyll/master/lib/jekyll/configuration.rb